### PR TITLE
Added customizable timestamp format

### DIFF
--- a/LogViewerLib/LogViewer.cs
+++ b/LogViewerLib/LogViewer.cs
@@ -51,6 +51,9 @@ namespace LogViewerLib {
     public static readonly DependencyProperty TemporaryDelayProperty =
         DependencyProperty.Register("TemporaryDelay", typeof(int), typeof(LogViewer), new PropertyMetadata(300));
 
+        /// <summary>
+        /// Allows to customize date and time format. Default value is "hh:mm:ss".
+        /// </summary>
         public string TimeStampFormat { get; set; } = "hh:mm:ss";
     #endregion
 

--- a/LogViewerLib/LogViewer.cs
+++ b/LogViewerLib/LogViewer.cs
@@ -50,6 +50,8 @@ namespace LogViewerLib {
     // DependencyProperty definition
     public static readonly DependencyProperty TemporaryDelayProperty =
         DependencyProperty.Register("TemporaryDelay", typeof(int), typeof(LogViewer), new PropertyMetadata(300));
+
+        public string TimeStampFormat { get; set; } = "hh:mm:ss";
     #endregion
 
 
@@ -248,7 +250,7 @@ namespace LogViewerLib {
           flowDoc.Blocks.Add(styledParagraph);
           if (styledString.LineHandling!=LineHandlingEnum.endOfLine || styledString.String.Length>0) {
             //not an empty line. Add the time
-            Run timeRun = new(styledString.Created.ToString("hh:mm:ss  ")) {
+            Run timeRun = new(styledString.Created.ToString($"{TimeStampFormat}  ")) { 
               Foreground = Brushes.DimGray
             };
             styledParagraph.Inlines.Add(timeRun);


### PR DESCRIPTION
Added string property TimeStampFormat. Change this property to customize how date and time are displayed in the LogViewer.
<img width="151" alt="image" src="https://github.com/PeterHuberSg/LogViewer/assets/13141581/8ecd7066-b4c0-4564-82e6-ccbf1fdd0286">
